### PR TITLE
use inclusive language

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Alternatively, please refer to the API documentation of the Baggage type.
 
 ## Contributing
 
-Please make sure to run the `./scripts/sanity.sh` script when contributing, it checks formatting and similar things.
+Please make sure to run the `./scripts/soundness.sh` script when contributing, it checks formatting and similar things.
 
 You can make ensure it always is run and passes before you push by installing a pre-push hook with git:
 
 ```
-echo './scripts/sanity.sh' > .git/hooks/pre-push
+echo './scripts/soundness.sh' > .git/hooks/pre-push
 ```

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -22,9 +22,9 @@ services:
       - CAP_NET_RAW
       - CAP_NET_BIND_SERVICE
 
-  sanity:
+  soundness:
     <<: *common
-    command: /bin/bash -xcl "./scripts/sanity.sh"
+    command: /bin/bash -xcl "./scripts/soundness.sh"
 
   docs:
     <<: *common

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift Distributed Tracing Baggage open source project
+##
+## Copyright (c) 2020 Apple Inc. and the Swift Distributed Tracing Baggage project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -eu
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+printf "=> Checking linux tests... "
+FIRST_OUT="$(git status --porcelain)"
+ruby "$here/../scripts/generate_linux_tests.rb" > /dev/null
+SECOND_OUT="$(git status --porcelain)"
+if [[ "$FIRST_OUT" != "$SECOND_OUT" ]]; then
+  printf "\033[0;31mmissing changes!\033[0m\n"
+  git --no-pager diff
+  exit 1
+else
+  printf "\033[0;32mokay.\033[0m\n"
+fi
+
+bash $here/validate_license_headers.sh
+bash $here/validate_language.sh
+bash $here/validate_format.sh
+bash $here/validate_naming.sh

--- a/scripts/validate_language.sh
+++ b/scripts/validate_language.sh
@@ -13,20 +13,19 @@
 ##===----------------------------------------------------------------------===##
 
 set -eu
-here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-printf "=> Checking linux tests... "
-FIRST_OUT="$(git status --porcelain)"
-ruby "$here/../scripts/generate_linux_tests.rb" > /dev/null
-SECOND_OUT="$(git status --porcelain)"
-if [[ "$FIRST_OUT" != "$SECOND_OUT" ]]; then
-  printf "\033[0;31mmissing changes!\033[0m\n"
-  git --no-pager diff
-  exit 1
-else
-  printf "\033[0;32mokay.\033[0m\n"
+printf "=> Checking for unacceptable language... "
+# This greps for unacceptable terminology. The square bracket[s] are so that
+# "git grep" doesn't find the lines that greps :).
+unacceptable_terms=(
+    -e blacklis[t]
+    -e whitelis[t]
+    -e slav[e]
+    -e sanit[y]
+)
+if git grep --color=never -i "${unacceptable_terms[@]}" > /dev/null; then
+    printf "\033[0;31mUnacceptable language found.\033[0m\n"
+    git grep -i "${unacceptable_terms[@]}"
+    exit 1
 fi
-
-bash $here/validate_license_headers.sh
-bash $here/validate_format.sh
-bash $here/validate_naming.sh
+printf "\033[0;32mokay.\033[0m\n"

--- a/scripts/validate_language.sh
+++ b/scripts/validate_language.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the Swift Distributed Tracing Baggage open source project
 ##
-## Copyright (c) 2020 Apple Inc. and the Swift Distributed Tracing Baggage project authors
+## Copyright (c) 2021 Apple Inc. and the Swift Distributed Tracing Baggage project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information

--- a/scripts/validate_license_headers.sh
+++ b/scripts/validate_license_headers.sh
@@ -35,7 +35,7 @@ function replace_acceptable_years() {
 }
 
 printf "=> Checking license headers\n"
-tmp=$(mktemp /tmp/.swift-baggage-context-sanity_XXXXXX)
+tmp=$(mktemp /tmp/.swift-baggage-context-soundness_XXXXXX)
 
 for language in swift-or-c bash dtrace; do
   printf "   * $language... "

--- a/scripts/validate_license_headers.sh
+++ b/scripts/validate_license_headers.sh
@@ -31,7 +31,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
   # this needs to replace all acceptable forms with 'YEARS'
-  sed -e 's/2019-2020/YEARS/' -e 's/2020/YEARS/'
+  sed -e 's/2019-2020/YEARS/' -e 's/2019-2021/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/'
 }
 
 printf "=> Checking license headers\n"


### PR DESCRIPTION
This removes use of "sanity" and adds the language check.

I don't have enough admin powers on this repo to unset the `pull request validation (sanity)` from being required (and mark the soundness one instead).